### PR TITLE
Depend on server class instead of hard-coded package name

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -101,7 +101,7 @@ define mariadb::server::config (
     owner   => 'root',
     group   => $mariadb::config::root_group,
     mode    => '0644',
-    require => Package['mariadb-server'],
+    require => Class['mariadb::server'],
   }
 
   if $notify_service {


### PR DESCRIPTION
`mariadb-server` package is only valid for Debian. Rely on the `mariadb::server` instead to accomplish what we need and avoid changing the params on this class.

The other option is to add a param and rely on the correct package (default to params class `package_name`). Thoughts?
