### PR TITLE
Avoid xtrabackup conflict

### DIFF
--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -127,10 +127,8 @@ class mariadb::cluster (
     require => Class['mariadb::server'],
   }
 
-  if $wsrep_sst_method == 'xtrabackup' and !defined(Package['percona-xtrabackup']) {
-    package { 'percona-xtrabackup':
-      ensure => installed
-    }
+  if $wsrep_sst_method == 'xtrabackup' {
+    ensure_packages(['percona-xtrabackup'])
   }
 
 }


### PR DESCRIPTION
Avoid package resource conflict for people using a separate xtrabackup module - We have an xtrabackup module because we're using it for backups, not just replication. It requires more configuration than just installing the package.
