### PR TITLE
fix $galera_ensure variable

### DIFF
--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -72,7 +72,7 @@ class mariadb::cluster (
   $package_names           = $mariadb::params::cluster_package_names,
   $package_ensure          = $mariadb::params::cluster_package_ensure,
   $galera_name             = $mariadb::params::galera_package_name,
-  $galera_ensure           = $mariadb::params::galera_package_ensure,
+  $galera_ensure           = $mariadb::params::cluster_package_ensure,
   $debiansysmaint_password = undef,
   $status_password         = undef,
   $repo_version            = '5.5',


### PR DESCRIPTION
seems to be a typo:
$mariadb::params::galera_package_ensure
should be:
$mariadb::params::cluster_package_ensure