### PR TITLE
changed default value from '' to undef

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -39,7 +39,7 @@ define mariadb::db (
   $charset     = 'utf8',
   $host        = 'localhost',
   $grant       = 'all',
-  $sql         = '',
+  $sql         = undef,
   $enforce_sql = false,
   $ensure      = 'present'
 ) {


### PR DESCRIPTION
Due to https://docs.puppetlabs.com/puppet/4.2/reference/lang_data_boolean.html empty strings are interpreted as true. Therefore the expression 

    # file dp.pp line 70
    if $sql {

will be true by default an will result in an puppet error when no sql is given